### PR TITLE
Added script for more control over branch wait

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,7 @@ dependencies:
     - "wp-e2e-tests/node_modules"
   override:
     - cd wp-e2e-tests && npm install
-    - if [ "$LIVEBRANCHES" = true ]; then until $(curl https://calypso.live/status?branch=$BRANCHNAME 2>/dev/null | grep -wqe "Ready\|NeedsPriming" ); do sleep 5; done; fi
+    - if [ "$LIVEBRANCHES" = true ]; then ./wait-for-running-branch.sh; fi
 
 test:
   pre:

--- a/wait-for-running-branch.sh
+++ b/wait-for-running-branch.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+if [ "" == "$BRANCHNAME" ]; then
+  echo "BRANCHNAME envvar not set";
+  exit;
+fi
+
+COUNT=0
+RESETCOUNT=60 # 5sec retry = Reset the branch after 5 minutes
+MAXCOUNT=120  # 5sec retry = Cancel after 10 minutes
+STATUS=$(curl https://calypso.live/status?branch=$BRANCHNAME 2>/dev/null)
+
+until $(echo $STATUS | grep -wqe "Ready\|NeedsPriming" ); do
+  if [ $COUNT == $MAXCOUNT ]; then
+    echo "Reached maximum allowed wait time, quitting"
+    exit 1
+  elif [ $COUNT == $RESETCOUNT ]; then
+    echo "Reached reset timeout, attempting to reset the branch"
+    curl https://calypso.live/?branch=$BRANCHNAME\&reset=true >/dev/null 2>&1
+  fi
+
+  # If it's still showing NotBuilt, then curl the branch directly rather than the status endpoint
+  if [ "NotBuilt" == "$STATUS" ]; then
+    echo "Branch status = $STATUS, running curl https://calypso.live/?branch=$BRANCHNAME"
+    curl https://calypso.live/?branch=$BRANCHNAME >/dev/null 2>&1
+  fi
+
+  sleep 5
+  STATUS=$(curl https://calypso.live/status?branch=$BRANCHNAME 2>/dev/null)
+  ((COUNT++))
+done


### PR DESCRIPTION
@alisterscott - My attempt in #13 apparently wasn't sufficient...sometimes you *do* need that initial curl to kick off the build.  I'm not sure why sometimes just polling for status is enough and other times not.

But this PR adds a more robust solution.  Let me know what you think.

The branches typically build in 1-3 minutes, so I set a timeout of 5 minutes before it attempts the `reset=true` parameter, and then it waits another 5 before assuming something is wrong and failing entirely.

The previous solution would time out in CircleCI after 10 minutes without anything printing to the screen, but I have a little bit of diagnostic data printing out now which would cause the overall timeout to jump to 20min (I think), so that's why I implemented an internal timeout.