### PR TITLE
Add a check to make sure the site is actually loaded and not showing …

### DIFF
--- a/wait-for-running-branch.sh
+++ b/wait-for-running-branch.sh
@@ -8,6 +8,7 @@ fi
 COUNT=0
 RESETCOUNT=60 # 5sec retry = Reset the branch after 5 minutes
 MAXCOUNT=120  # 5sec retry = Cancel after 10 minutes
+SITEWAITCOUNT=30 # 5sec retry = Stop waiting after 2.5 minutes
 
 STATUS=$(curl https://calypso.live/status?branch=$BRANCHNAME 2>/dev/null)
 
@@ -38,4 +39,20 @@ until $(echo $STATUS | grep -wqe "Ready\|NeedsPriming" ); do
   STATUS=$(curl https://calypso.live/status?branch=$BRANCHNAME 2>/dev/null)
   ((COUNT++))
   echo "Branch status now = $STATUS https://calypso.live/status?branch=$BRANCHNAME"
+done
+
+SITE=$(curl https://calypso.live/?branch=$BRANCHNAME 2>/dev/null)
+COUNT=0
+until ! $(echo $SITE | grep -q "dserve" ); do
+  if [ $COUNT == $SITEWAITCOUNT ]; then
+    echo "Reached maximum allowed wait time, quitting"
+    exit 1
+  fi
+
+  echo "Branch status is $STATUS, but site is not up yet. Waiting until it is up."
+
+  ((COUNT++))
+  sleep 5
+  SITE=$(curl https://calypso.live/?branch=$BRANCHNAME 2>/dev/null)
+  STATUS=$(curl https://calypso.live/status?branch=$BRANCHNAME 2>/dev/null)
 done


### PR DESCRIPTION
…dserve

I added a check for "deserve" when a curl is done after the site should be up. If it sees dserve in the response it will keep trying until it doesn't or 2.5 minutes passes.