### PR TITLE
Run tests in Parallel containers to improve speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ parameters:
   calypsoProject:
     type: string
     default: ""
+  jetpackProject:
+    type: string
+    default: ""
   E2E_BRANCH:
     type: string
     default: "master"
@@ -48,10 +51,10 @@ parameters:
     default: ""
   SKIP_DOMAIN_TESTS:
     type: string
-    default: ""
+    default: "false"
   HORIZON_TESTS:
     type: string
-    default: ""
+    default: "false"
 
 references:
   set-e2e-variables: &set-e2e-variables
@@ -74,6 +77,7 @@ references:
       echo 'export JETPACKHOST=<< pipeline.parameters.JETPACKHOST >>' >> $BASH_ENV &&
       echo 'export SKIP_DOMAIN_TESTS=<< pipeline.parameters.SKIP_DOMAIN_TESTS >>' >> $BASH_ENV &&
       echo 'export HORIZON_TESTS=<< pipeline.parameters.HORIZON_TESTS >>' >> $BASH_ENV
+
 jobs:
   run-tests:
     working_directory: ~/wp-calypso

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso/test/e2e
-          echo "export TESTFILES=$(circleci tests glob "specs*/**/*spec.js" | circleci tests split | tr '\n' ',' )" >> $BASH_ENV
+          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split | tr '\n' ',' )\"" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
       - run: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} -f ${TESTFILES} $RUN_ARGS
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso/test/e2e
-          TESTFILES="$(circleci tests glob "specs*/**/*spec.js" | circleci tests split | tr '\n' ',' )"
+          echo "export TESTFILES=$(circleci tests glob "specs*/**/*spec.js" | circleci tests split | tr '\n' ',' )" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
       - run: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} -f ${TESTFILES} $RUN_ARGS
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,7 @@ jobs:
     docker:
       - image: 'circleci/node:$NODE_VERSION-browsers'
     steps:
+      - checkout
       - run: if [ "<< pipeline.parameters.LIVEBRANCHES >>" = true ]; then ./wait-for-running-branch.sh; fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
         environment:
           NODE_ENV: test
           TARGET: BRANCHES
-    parallelism: 3
+    parallelism: 4
     steps:
       - checkout
       - run: *set-e2e-variables

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,15 @@ parameters:
   RUN_SPECIFIED:
     type: string
     default: ""
+  JETPACKHOST:
+    type: string
+    default: ""
+  SKIP_DOMAIN_TESTS:
+    type: string
+    default: ""
+  HORIZON_TESTS:
+    type: string
+    default: ""
 
 references:
   set-e2e-variables: &set-e2e-variables
@@ -61,7 +70,10 @@ references:
       echo 'export DEPLOY_USER=<< pipeline.parameters.DEPLOY_USER >>' >> $BASH_ENV &&
       echo 'export PROD_REVISION=<< pipeline.parameters.PROD_REVISION >>' >> $BASH_ENV &&
       echo 'export TO_DEPLOY_REVISION=<< pipeline.parameters.TO_DEPLOY_REVISION >>' >> $BASH_ENV &&
-      echo 'export RUN_SPECIFIED=<< pipeline.parameters.RUN_SPECIFIED >>' >> $BASH_ENV
+      echo 'export RUN_SPECIFIED=<< pipeline.parameters.RUN_SPECIFIED >>' >> $BASH_ENV &&
+      echo 'export JETPACKHOST=<< pipeline.parameters.JETPACKHOST >>' >> $BASH_ENV &&
+      echo 'export SKIP_DOMAIN_TESTS=<< pipeline.parameters.SKIP_DOMAIN_TESTS >>' >> $BASH_ENV &&
+      echo 'export HORIZON_TESTS=<< pipeline.parameters.HORIZON_TESTS >>' >> $BASH_ENV
 jobs:
   run-tests:
     working_directory: ~/wp-calypso

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso/test/e2e
-          echo "export TESTFILES=\"$(circleci tests glob "specs/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
+          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,67 @@
-version: 2
+version: 2.1
+
+parameters:
+  LIVEBRANCHES:
+    type: boolean
+    default: false
+  BRANCHNAME:
+    type: string
+    default: ""
+  calypsoProject:
+    type: string
+    default: ""
+  E2E_BRANCH:
+    type: string
+    default: ""
+  pullRequestNum:
+    type: string
+    default: ""
+  prContext:
+    type: string
+    default: ""
+  RUN_ARGS:
+    type: string
+    default: ""
+  calypsoSha:
+    type: string
+    default: ""
+  testFlag:
+    type: string
+    default: ""
+  sha:
+    type: string
+    default: ""
+  DEPLOY_USER:
+    type: string
+    default: ""
+  PROD_REVISION:
+    type: string
+    default: ""
+  TO_DEPLOY_REVISION:
+    type: string
+    default: ""
+  RUN_SPECIFIED:
+    type: string
+    default: ""
+
+references:
+  set-e2e-variables: &set-e2e-variables
+    name: Set e2e environment variables
+    command: |
+      echo 'export LIVEBRANCHES=<< pipeline.parameters.LIVEBRANCHES >>' >> $BASH_ENV &&
+      echo 'export BRANCHNAME=<< pipeline.parameters.BRANCHNAME >>' >> $BASH_ENV &&
+      echo 'export calypsoProject=<< pipeline.parameters.calypsoProject >>' >> $BASH_ENV &&
+      echo 'export E2E_BRANCH=<< pipeline.parameters.E2E_BRANCH >>' >> $BASH_ENV &&
+      echo 'export pullRequestNum=<< pipeline.parameters.pullRequestNum >>' >> $BASH_ENV &&
+      echo 'export prContext=<< pipeline.parameters.prContext >>' >> $BASH_ENV &&
+      echo 'export RUN_ARGS=<< pipeline.parameters.RUN_ARGS >>' >> $BASH_ENV &&
+      echo 'export calypsoSha=<< pipeline.parameters.calypsoSha >>' >> $BASH_ENV &&
+      echo 'export testFlag=<< pipeline.parameters.testFlag >>' >> $BASH_ENV &&
+      echo 'export sha=<< pipeline.parameters.sha >>' >> $BASH_ENV &&
+      echo 'export DEPLOY_USER=<< pipeline.parameters.DEPLOY_USER >>' >> $BASH_ENV &&
+      echo 'export PROD_REVISION=<< pipeline.parameters.PROD_REVISION >>' >> $BASH_ENV &&
+      echo 'export TO_DEPLOY_REVISION=<< pipeline.parameters.TO_DEPLOY_REVISION >>' >> $BASH_ENV &&
+      echo 'export RUN_SPECIFIED=<< pipeline.parameters.RUN_SPECIFIED >>' >> $BASH_ENV
 jobs:
   run-tests:
     working_directory: ~/wp-calypso
@@ -10,6 +73,7 @@ jobs:
     parallelism: 3
     steps:
       - checkout
+      - run: *set-e2e-variables
       - run: git submodule init
       - run: git submodule update --remote --force
       - run: cd wp-calypso && git checkout origin/${E2E_BRANCH-master}
@@ -25,7 +89,6 @@ jobs:
           key: v1-npmcache-{{ checksum "wp-calypso/.nvmrc" }}-{{ checksum "wp-calypso/test/e2e/package.json" }}
           paths:
             - "~/.npm"
-      - run: if [ "$LIVEBRANCHES" = true ]; then ./wait-for-running-branch.sh; fi
       - run: cd wp-calypso/test/e2e && npm run decryptconfig
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
@@ -51,7 +114,7 @@ jobs:
     docker:
       - image: 'circleci/node:$NODE_VERSION-browsers'
     steps:
-      - run: if [ "$LIVEBRANCHES" = true ]; then ./wait-for-running-branch.sh; fi
+      - run: if [ "<< pipeline.parameters.LIVEBRANCHES >>" = true ]; then ./wait-for-running-branch.sh; fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso/test/e2e
-          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
+          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=timings | tr '\n' ',' )\"" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
         environment:
           NODE_ENV: test
           TARGET: BRANCHES
-    parallelism: 4
+    parallelism: 3
     steps:
       - checkout
       - run: *set-e2e-variables

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso/test/e2e
-          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=timings | tr '\n' ',' )\"" >> $BASH_ENV
+          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,11 @@ jobs:
       - run: |
           cd wp-calypso/test/e2e
           echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
+          echo "export CIRCLE_SHA1=${calypsoSha" >> $BASH_ENV
+          echo "export CIRCLE_PULL_REQUEST=https://github.com/Automattic/wp-calypso/pull/${pullRequestNum}" >> $BASH_ENV
+          echo "export CIRCLE_PULL_REQUESTS=https://github.com/Automattic/wp-calypso/pull/${pullRequestNum}" >> $BASH_ENV
+          echo "export CI_PULL_REQUEST=https://github.com/Automattic/wp-calypso/pull/${pullRequestNum}" >> $BASH_ENV
+          echo "export CI_PULL_REQUESTS=https://github.com/Automattic/wp-calypso/pull/${pullRequestNum}" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
       - run: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} -f ${TESTFILES} $RUN_ARGS
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  run-tests:
     working_directory: ~/wp-calypso
     docker:
       - image: 'circleci/node:$NODE_VERSION-browsers'
@@ -45,3 +45,19 @@ jobs:
           path: wp-calypso/test/e2e/reports/
       - store_artifacts:
           path: wp-calypso/test/e2e/screenshots/
+
+  wait-calypso-live:
+    working_directory: ~/wp-calypso
+    docker:
+      - image: 'circleci/node:$NODE_VERSION-browsers'
+    steps:
+      - run: if [ "$LIVEBRANCHES" = true ]; then ./wait-for-running-branch.sh; fi
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - wait-calypso-live
+      - run-tests:
+          requires:
+            - wait-calypso-live

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           command: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} -f ${TESTFILES} $RUN_ARGS
       - run:
           name: Report Status
-          when: alwaysch
+          when: always
           command: if [ "$CIRCLE_NODE_INDEX" = 0 ]; then ./check_nodes_for_status.sh; fi
       - store_test_results:
           path: wp-calypso/test/e2e/reports/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@ version: 2.1
 
 parameters:
   LIVEBRANCHES:
-    type: boolean
-    default: false
+    type: string
+    default: "false"
   BRANCHNAME:
     type: string
     default: ""
@@ -12,7 +12,7 @@ parameters:
     default: ""
   E2E_BRANCH:
     type: string
-    default: ""
+    default: "master"
   pullRequestNum:
     type: string
     default: ""

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
         environment:
           NODE_ENV: test
           TARGET: BRANCHES
-    parallelism: 4
+    parallelism: 3
     steps:
       - checkout
       - run: git submodule init
@@ -30,7 +30,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso/test/e2e
-          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=timings | tr '\n' ',' )\"" >> $BASH_ENV
+          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
       - run: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} -f ${TESTFILES} $RUN_ARGS
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
         environment:
           NODE_ENV: test
           TARGET: BRANCHES
+    parallelism: 4
     steps:
       - checkout
       - run: git submodule init
@@ -27,19 +28,14 @@ jobs:
       - run: if [ "$LIVEBRANCHES" = true ]; then ./wait-for-running-branch.sh; fi
       - run: cd wp-calypso/test/e2e && npm run decryptconfig
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
-      - run: echo running test command "./run.sh -p -R ${testFlag} $RUN_ARGS"
-      - run: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} $RUN_ARGS
+      - run: |
+          TESTFILES=$(circleci tests glob "specs*/**/*spec.js" | circleci tests split)
+          echo "[${TESTFILES}]" > testfiles.json
+      - run: echo running test command "./run.sh -p -R ${testFlag} -f testfiles.json $RUN_ARGS"
+      - run: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} -f testfiles.json $RUN_ARGS
       - store_test_results:
           path: wp-calypso/test/e2e/reports/
       - store_artifacts:
           path: wp-calypso/test/e2e/reports/
       - store_artifacts:
           path: wp-calypso/test/e2e/screenshots/
-      - run:
-          name: Notify webhook of failed build
-          when: on_fail
-          command: ./wp-calypso/test/e2e/scripts/notify-webhook.sh failed
-      - run:
-          name: Notify webhook of successful build
-          when: on_success
-          command: ./wp-calypso/test/e2e/scripts/notify-webhook.sh success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run: |
           cd wp-calypso/test/e2e
           echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
-          echo "export CIRCLE_SHA1=${calypsoSha" >> $BASH_ENV
+          echo "export CIRCLE_SHA1=${calypsoSha}" >> $BASH_ENV
           echo "export CIRCLE_PULL_REQUEST=https://github.com/Automattic/wp-calypso/pull/${pullRequestNum}" >> $BASH_ENV
           echo "export CIRCLE_PULL_REQUESTS=https://github.com/Automattic/wp-calypso/pull/${pullRequestNum}" >> $BASH_ENV
           echo "export CI_PULL_REQUEST=https://github.com/Automattic/wp-calypso/pull/${pullRequestNum}" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso/test/e2e
-          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
+          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=timings | tr '\n' ',' )\"" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
       - run: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} -f ${TESTFILES} $RUN_ARGS
       - store_test_results:
@@ -39,7 +39,3 @@ jobs:
           path: wp-calypso/test/e2e/reports/
       - store_artifacts:
           path: wp-calypso/test/e2e/screenshots/
-experimental:
-  notify:
-    webhooks:
-      - url: https://a8c-gh-e2e-bridge.go-vip.co/circleciwebhook

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,14 @@ jobs:
       - run: |
           cd wp-calypso/test/e2e
           echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
-          echo "export CIRCLE_SHA1=${calypsoSha}" >> $BASH_ENV
-          echo "export CIRCLE_PULL_REQUEST=https://github.com/Automattic/wp-calypso/pull/${pullRequestNum}" >> $BASH_ENV
-          echo "export CIRCLE_PULL_REQUESTS=https://github.com/Automattic/wp-calypso/pull/${pullRequestNum}" >> $BASH_ENV
-          echo "export CI_PULL_REQUEST=https://github.com/Automattic/wp-calypso/pull/${pullRequestNum}" >> $BASH_ENV
-          echo "export CI_PULL_REQUESTS=https://github.com/Automattic/wp-calypso/pull/${pullRequestNum}" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
-      - run: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} -f ${TESTFILES} $RUN_ARGS
+      - run:
+          name: Run Tests
+          command: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} -f ${TESTFILES} $RUN_ARGS
+      - run:
+          name: Report Status
+          when: alwaysch
+          command: if [ "$CIRCLE_NODE_INDEX" = 0 ]; then ./check_nodes_for_status.sh; fi
       - store_test_results:
           path: wp-calypso/test/e2e/reports/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso/test/e2e
-          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
+          echo "export TESTFILES=\"$(circleci tests glob "specs/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,11 +50,11 @@ parameters:
     type: string
     default: ""
   SKIP_DOMAIN_TESTS:
-    type: string
-    default: "false"
+    type: boolean
+    default: false
   HORIZON_TESTS:
-    type: string
-    default: "false"
+    type: boolean
+    default: false
 
 references:
   set-e2e-variables: &set-e2e-variables
@@ -63,6 +63,7 @@ references:
       echo 'export LIVEBRANCHES=<< pipeline.parameters.LIVEBRANCHES >>' >> $BASH_ENV &&
       echo 'export BRANCHNAME=<< pipeline.parameters.BRANCHNAME >>' >> $BASH_ENV &&
       echo 'export calypsoProject=<< pipeline.parameters.calypsoProject >>' >> $BASH_ENV &&
+      echo 'export jetpackProject=<< pipeline.parameters.jetpackProject >>' >> $BASH_ENV &&
       echo 'export E2E_BRANCH=<< pipeline.parameters.E2E_BRANCH >>' >> $BASH_ENV &&
       echo 'export pullRequestNum=<< pipeline.parameters.pullRequestNum >>' >> $BASH_ENV &&
       echo 'export prContext=<< pipeline.parameters.prContext >>' >> $BASH_ENV &&

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,9 @@ references:
       echo 'export E2E_BRANCH=<< pipeline.parameters.E2E_BRANCH >>' >> $BASH_ENV &&
       echo 'export pullRequestNum=<< pipeline.parameters.pullRequestNum >>' >> $BASH_ENV &&
       echo 'export prContext=<< pipeline.parameters.prContext >>' >> $BASH_ENV &&
-      echo 'export RUN_ARGS=<< pipeline.parameters.RUN_ARGS >>' >> $BASH_ENV &&
+      echo 'export RUN_ARGS="<< pipeline.parameters.RUN_ARGS" >>' >> $BASH_ENV &&
       echo 'export calypsoSha=<< pipeline.parameters.calypsoSha >>' >> $BASH_ENV &&
-      echo 'export testFlag=<< pipeline.parameters.testFlag >>' >> $BASH_ENV &&
+      echo 'export testFlag="<< pipeline.parameters.testFlag" >>' >> $BASH_ENV &&
       echo 'export sha=<< pipeline.parameters.sha >>' >> $BASH_ENV &&
       echo 'export DEPLOY_USER=<< pipeline.parameters.DEPLOY_USER >>' >> $BASH_ENV &&
       echo 'export PROD_REVISION=<< pipeline.parameters.PROD_REVISION >>' >> $BASH_ENV &&
@@ -115,7 +115,8 @@ jobs:
       - image: 'circleci/node:$NODE_VERSION-browsers'
     steps:
       - checkout
-      - run: if [ "<< pipeline.parameters.LIVEBRANCHES >>" = true ]; then ./wait-for-running-branch.sh; fi
+      - run: *set-e2e-variables
+      - run: if [ "$LIVEBRANCHES" = true ]; then ./wait-for-running-branch.sh; fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,3 +39,7 @@ jobs:
           path: wp-calypso/test/e2e/reports/
       - store_artifacts:
           path: wp-calypso/test/e2e/screenshots/
+experimental:
+  notify:
+    webhooks:
+      - url: https://a8c-gh-e2e-bridge.go-vip.co/circleciwebhook

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,10 @@ jobs:
       - run: cd wp-calypso/test/e2e && npm run decryptconfig
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
-          TESTFILES=$(circleci tests glob "specs*/**/*spec.js" | circleci tests split)
-          echo "[${TESTFILES}]" > testfiles.json
-      - run: echo running test command "./run.sh -p -R ${testFlag} -f testfiles.json $RUN_ARGS"
-      - run: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} -f testfiles.json $RUN_ARGS
+          cd wp-calypso/test/e2e
+          TESTFILES="$(circleci tests glob "specs*/**/*spec.js" | circleci tests split | tr '\n' ',' )"
+      - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
+      - run: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} -f ${TESTFILES} $RUN_ARGS
       - store_test_results:
           path: wp-calypso/test/e2e/reports/
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso/test/e2e
-          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split | tr '\n' ',' )\"" >> $BASH_ENV
+          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
       - run: cd wp-calypso/test/e2e && ./run.sh -R ${testFlag} -f ${TESTFILES} $RUN_ARGS
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,9 @@ references:
       echo 'export E2E_BRANCH=<< pipeline.parameters.E2E_BRANCH >>' >> $BASH_ENV &&
       echo 'export pullRequestNum=<< pipeline.parameters.pullRequestNum >>' >> $BASH_ENV &&
       echo 'export prContext=<< pipeline.parameters.prContext >>' >> $BASH_ENV &&
-      echo 'export RUN_ARGS="<< pipeline.parameters.RUN_ARGS" >>' >> $BASH_ENV &&
+      echo 'export RUN_ARGS="<< pipeline.parameters.RUN_ARGS >>"' >> $BASH_ENV &&
       echo 'export calypsoSha=<< pipeline.parameters.calypsoSha >>' >> $BASH_ENV &&
-      echo 'export testFlag="<< pipeline.parameters.testFlag" >>' >> $BASH_ENV &&
+      echo 'export testFlag="<< pipeline.parameters.testFlag >>"' >> $BASH_ENV &&
       echo 'export sha=<< pipeline.parameters.sha >>' >> $BASH_ENV &&
       echo 'export DEPLOY_USER=<< pipeline.parameters.DEPLOY_USER >>' >> $BASH_ENV &&
       echo 'export PROD_REVISION=<< pipeline.parameters.PROD_REVISION >>' >> $BASH_ENV &&

--- a/check_nodes_for_status.sh
+++ b/check_nodes_for_status.sh
@@ -12,6 +12,10 @@ STATUS_1=$(eval "${CALL} | ${STATUS_CALL_1}")
 STATUS_2=$(eval "${CALL} | ${STATUS_CALL_2}")
 STATUS_3=$(eval "${CALL} | ${STATUS_CALL_3}")
 
+    echo "Node 1 status: ${STATUS_1}"
+    echo "Node 2 status: ${STATUS_2}"
+    echo "Node 3 status: ${STATUS_3}"
+
 until [[ $STATUS_1 == "\"success\"" || $STATUS_1 == "\"failed\"" ]] && [[ $STATUS_2 == "\"success\"" || $STATUS_2 == "\"failed\"" ]] && [[ $STATUS_3 == "\"success\"" || $STATUS_3 == "\"failed\"" ]] ; do
     echo "Node 1 status: ${STATUS_1}"
     echo "Node 2 status: ${STATUS_2}"
@@ -30,7 +34,7 @@ until [[ $STATUS_1 == "\"success\"" || $STATUS_1 == "\"failed\"" ]] && [[ $STATU
     ((COUNT++))
 done
 
-if [[ STATUS_1 == "\"failed\"" ]] || [[ STATUS_2 == "\"failed\"" ]] || [[ STATUS_3 == "\"failed\"" ]]; then
+if [[ $STATUS_1 == "\"failed\"" ]] || [[ $STATUS_2 == "\"failed\"" ]] || [[ $STATUS_3 == "\"failed\"" ]]; then
     echo "Calling endpoint with failed status"
     ./wp-calypso/test/e2e/scripts/notify-webhook.sh failed
 else

--- a/check_nodes_for_status.sh
+++ b/check_nodes_for_status.sh
@@ -12,9 +12,9 @@ STATUS_1=$(eval "${CALL} | ${STATUS_CALL_1}")
 STATUS_2=$(eval "${CALL} | ${STATUS_CALL_2}")
 STATUS_3=$(eval "${CALL} | ${STATUS_CALL_3}")
 
-    echo "Node 1 status: ${STATUS_1}"
-    echo "Node 2 status: ${STATUS_2}"
-    echo "Node 3 status: ${STATUS_3}"
+echo "Node 1 status: ${STATUS_1}"
+echo "Node 2 status: ${STATUS_2}"
+echo "Node 3 status: ${STATUS_3}"
 
 until [[ $STATUS_1 == "\"success\"" || $STATUS_1 == "\"failed\"" ]] && [[ $STATUS_2 == "\"success\"" || $STATUS_2 == "\"failed\"" ]] && [[ $STATUS_3 == "\"success\"" || $STATUS_3 == "\"failed\"" ]] ; do
     echo "Node 1 status: ${STATUS_1}"

--- a/check_nodes_for_status.sh
+++ b/check_nodes_for_status.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+COUNT=0
+MAXCOUNT=60 # 10 sec retry = Reset the branch after 10 minutes
+
+CALL="curl https://circleci.com/api/v1.1/project/github/Automattic/wp-e2e-tests-for-branches/${CIRCLE_BUILD_NUM}"
+STATUS_CALL_1="jq '.steps[] | select(.name==\"Run Tests\") | .actions[] | select(.index==0) | .status'"
+STATUS_CALL_2="jq '.steps[] | select(.name==\"Run Tests\") | .actions[] | select(.index==1) | .status'"
+STATUS_CALL_3="jq '.steps[] | select(.name==\"Run Tests\") | .actions[] | select(.index==2) | .status'"
+
+STATUS_1=$(eval "${CALL} | ${STATUS_CALL_1}")
+STATUS_2=$(eval "${CALL} | ${STATUS_CALL_2}")
+STATUS_3=$(eval "${CALL} | ${STATUS_CALL_3}")
+
+until [[ $STATUS_1 == "\"success\"" || $STATUS_1 == "\"failed\"" ]] && [[ $STATUS_2 == "\"success\"" || $STATUS_2 == "\"failed\"" ]] && [[ $STATUS_3 == "\"success\"" || $STATUS_3 == "\"failed\"" ]] ; do
+    echo "Node 1 status: ${STATUS_1}"
+    echo "Node 2 status: ${STATUS_2}"
+    echo "Node 3 status: ${STATUS_3}"
+
+    if [ $COUNT == $MAXCOUNT ]; then
+        echo "Reached maximum allowed wait time, quitting"
+        echo "Calling endpoint with failed status"
+        ./wp-calypso/test/e2e/scripts/notify-webhook.sh failed
+        exit 1
+    fi
+    sleep 10
+    STATUS_1=$(eval "${CALL} | ${STATUS_CALL_1}")
+    STATUS_2=$(eval "${CALL} | ${STATUS_CALL_2}")
+    STATUS_3=$(eval "${CALL} | ${STATUS_CALL_3}")
+    ((COUNT++))
+done
+
+if [[ STATUS_1 == "\"failed\"" ]] || [[ STATUS_2 == "\"failed\"" ]] || [[ STATUS_3 == "\"failed\"" ]]; then
+    echo "Calling endpoint with failed status"
+    ./wp-calypso/test/e2e/scripts/notify-webhook.sh failed
+else
+    echo "Calling endpoint with success status"
+    ./wp-calypso/test/e2e/scripts/notify-webhook.sh success
+fi

--- a/check_nodes_for_status.sh
+++ b/check_nodes_for_status.sh
@@ -8,19 +8,15 @@ STATUS_CALL_1="jq '.steps[] | select(.name==\"Run Tests\") | .actions[] | select
 STATUS_CALL_2="jq '.steps[] | select(.name==\"Run Tests\") | .actions[] | select(.index==1) | .status'"
 STATUS_CALL_3="jq '.steps[] | select(.name==\"Run Tests\") | .actions[] | select(.index==2) | .status'"
 
-STATUS_1=$(eval "${CALL} | ${STATUS_CALL_1}")
-STATUS_2=$(eval "${CALL} | ${STATUS_CALL_2}")
-STATUS_3=$(eval "${CALL} | ${STATUS_CALL_3}")
+STATUS_1=$(eval "\"${CALL}\" | ${STATUS_CALL_1}")
+STATUS_2=$(eval "\"${CALL}\" | ${STATUS_CALL_2}")
+STATUS_3=$(eval "\"${CALL}\" | ${STATUS_CALL_3}")
 
 echo "Node 1 status: ${STATUS_1}"
 echo "Node 2 status: ${STATUS_2}"
 echo "Node 3 status: ${STATUS_3}"
 
 until [[ $STATUS_1 == "\"success\"" || $STATUS_1 == "\"failed\"" ]] && [[ $STATUS_2 == "\"success\"" || $STATUS_2 == "\"failed\"" ]] && [[ $STATUS_3 == "\"success\"" || $STATUS_3 == "\"failed\"" ]] ; do
-    echo "Node 1 status: ${STATUS_1}"
-    echo "Node 2 status: ${STATUS_2}"
-    echo "Node 3 status: ${STATUS_3}"
-
     if [ $COUNT == $MAXCOUNT ]; then
         echo "Reached maximum allowed wait time, quitting"
         echo "Calling endpoint with failed status"
@@ -32,6 +28,10 @@ until [[ $STATUS_1 == "\"success\"" || $STATUS_1 == "\"failed\"" ]] && [[ $STATU
     STATUS_2=$(eval "${CALL} | ${STATUS_CALL_2}")
     STATUS_3=$(eval "${CALL} | ${STATUS_CALL_3}")
     ((COUNT++))
+
+    echo "Node 1 status: ${STATUS_1}"
+    echo "Node 2 status: ${STATUS_2}"
+    echo "Node 3 status: ${STATUS_3}"
 done
 
 if [[ $STATUS_1 == "\"failed\"" ]] || [[ $STATUS_2 == "\"failed\"" ]] || [[ $STATUS_3 == "\"failed\"" ]]; then

--- a/check_nodes_for_status.sh
+++ b/check_nodes_for_status.sh
@@ -8,9 +8,9 @@ STATUS_CALL_1="jq '.steps[] | select(.name==\"Run Tests\") | .actions[] | select
 STATUS_CALL_2="jq '.steps[] | select(.name==\"Run Tests\") | .actions[] | select(.index==1) | .status'"
 STATUS_CALL_3="jq '.steps[] | select(.name==\"Run Tests\") | .actions[] | select(.index==2) | .status'"
 
-STATUS_1=$(eval "\"${CALL}\" | ${STATUS_CALL_1}")
-STATUS_2=$(eval "\"${CALL}\" | ${STATUS_CALL_2}")
-STATUS_3=$(eval "\"${CALL}\" | ${STATUS_CALL_3}")
+STATUS_1=$(eval "${CALL} | ${STATUS_CALL_1}")
+STATUS_2=$(eval "${CALL} | ${STATUS_CALL_2}")
+STATUS_3=$(eval "${CALL} | ${STATUS_CALL_3}")
 
 echo "Node 1 status: ${STATUS_1}"
 echo "Node 2 status: ${STATUS_2}"


### PR DESCRIPTION
This PR changes the way that tests are run, splitting them across 3 CircleCI containers to improve speed. 

Additionally, there is a new script that runs that checks the status of tests in all 3 containers before notifying the existing webhook that updates Github.

An example of this running is at https://circleci.com/gh/Automattic/wp-e2e-tests-for-branches/22399