### PR TITLE
Notify gh bridge if wait for calypso fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,10 @@ jobs:
       - checkout
       - run: *set-e2e-variables
       - run: if [ "$LIVEBRANCHES" = true ]; then ./wait-for-running-branch.sh; fi
+      - run:
+          when: on_fail
+          command: |
+            ./wp-calypso/test/e2e/scripts/notify-webhook.sh failed
 
 workflows:
   version: 2


### PR DESCRIPTION
This just adds a step to config to run the notify webhook if the wait for calypso fails. This will make sure that the PR is updated if that fails