### PR TITLE
Init submodule so I can call status update script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,8 @@ jobs:
     steps:
       - checkout
       - run: *set-e2e-variables
+      - run: git submodule init
+      - run: git submodule update --remote --force
       - run: if [ "$LIVEBRANCHES" = true ]; then ./wait-for-running-branch.sh; fi
       - run:
           when: on_fail


### PR DESCRIPTION
This fixes the issue of the status update script failing when calypso wait fails. 