### PR TITLE
Only run signup tests if there are changes in signup code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,11 +110,11 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso
-          if (( ! git diff --exit-code .. origin/master -- client/signup) && ( ${LIVEBRANCHES} )); then
-              echo "export SUITE_TAG=\"parallel\"" >> $BASH_ENV
-          else
+          if (( ! git diff --exit-code .. origin/master -- client/signup) || ( ! ${LIVEBRANCHES} )); then
               echo "Running Signup Tests"
               echo "export SPLIT_BY=\"--split-by=filesize \"" >> $BASH_ENV
+          else
+              echo "export SUITE_TAG=\"parallel\"" >> $BASH_ENV
           fi
       - run: |
           cd wp-calypso/test/e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,9 @@ parameters:
   HORIZON_TESTS:
     type: boolean
     default: false
+  FORCE_ALL:
+    type: boolean
+    default: false
 
 references:
   set-e2e-variables: &set-e2e-variables
@@ -77,7 +80,8 @@ references:
       echo 'export RUN_SPECIFIED=<< pipeline.parameters.RUN_SPECIFIED >>' >> $BASH_ENV &&
       echo 'export JETPACKHOST=<< pipeline.parameters.JETPACKHOST >>' >> $BASH_ENV &&
       echo 'export SKIP_DOMAIN_TESTS=<< pipeline.parameters.SKIP_DOMAIN_TESTS >>' >> $BASH_ENV &&
-      echo 'export HORIZON_TESTS=<< pipeline.parameters.HORIZON_TESTS >>' >> $BASH_ENV
+      echo 'export HORIZON_TESTS=<< pipeline.parameters.HORIZON_TESTS >>' >> $BASH_ENV &&
+      echo 'export FORCE_ALL=<< pipeline.parameters.FORCE_ALL >>' >> $BASH_ENV
 
 jobs:
   run-tests:
@@ -110,7 +114,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso
-          if (( ( ! git diff --exit-code .. origin/master -- client/signup && ! git diff --exit-code .. origin/master -- client/blocks/signup-form && ! git diff --exit-code .. origin/master -- client/lib/signup) || ! ${LIVEBRANCHES} || ${FORCE_ALL} )); then
+          if [[ -n $(git diff --exit-code .. origin/master -- client/signup) || -n $(git diff --exit-code .. origin/master -- client/blocks/signup-form) || -n $(git diff --exit-code .. origin/master -- client/lib/signup) ]] || ! ${LIVEBRANCHES} || ${FORCE_ALL}; then
               echo "Running Signup Tests"
               echo "export SPLIT_BY=\"--split-by=filesize \"" >> $BASH_ENV
           else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso
-          if (( ! git diff --exit-code .. origin/master -- client/signup) || ( ! ${LIVEBRANCHES} )); then
+          if (( ( ! git diff --exit-code .. origin/master -- client/signup && ! git diff --exit-code .. origin/master -- client/blocks/signup-form && ! git diff --exit-code .. origin/master -- client/lib/signup) || ! ${LIVEBRANCHES} || ${FORCE_ALL} )); then
               echo "Running Signup Tests"
               echo "export SPLIT_BY=\"--split-by=filesize \"" >> $BASH_ENV
           else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,14 +110,15 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso
-          if [! git diff --exit-code ${BRANCHNAME} master -- client/signup] && [! ${LIVEBRANCHES}=true ]; then
+          if (( ! git diff --exit-code ${BRANCHNAME} origin/master -- client/signup) && (! ${LIVEBRANCHES}==true ); then
               echo "Running Signup Tests"
+              echo "export SPLIT_BY=\"--split-by=filesize \"" >> $BASH_ENV
           else
               echo "export SUITE_TAG=\"parallel\"" >> $BASH_ENV
           fi
       - run: |
           cd wp-calypso/test/e2e
-          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
+          echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split ${SPLIT_BY}| tr '\n' ',' )\"" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"
       - run:
           name: Run Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,11 +110,11 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso
-          if (( ! git diff --exit-code ${BRANCHNAME} origin/master -- client/signup) && (! ${LIVEBRANCHES}==true )); then
+          if (( ! git diff --exit-code .. origin/master -- client/signup) && ( ${LIVEBRANCHES} )); then
+              echo "export SUITE_TAG=\"parallel\"" >> $BASH_ENV
+          else
               echo "Running Signup Tests"
               echo "export SPLIT_BY=\"--split-by=filesize \"" >> $BASH_ENV
-          else
-              echo "export SUITE_TAG=\"parallel\"" >> $BASH_ENV
           fi
       - run: |
           cd wp-calypso/test/e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,13 @@ jobs:
       - run: cd wp-calypso/test/e2e && npm run decryptconfig
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
+          cd wp-calypso
+          if ! git diff --exit-code ${E2E_BRANCH} master --client/signup; then
+              echo "Running Signup Tests"
+          else
+              echo "export SUITE_TAG=\"parallel\"" >> $BASH_ENV
+          fi
+      - run: |
           cd wp-calypso/test/e2e
           echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split --split-by=filesize | tr '\n' ',' )\"" >> $BASH_ENV
       - run: echo running test command "./run.sh -p -R ${testFlag} -f ${TESTFILES} $RUN_ARGS"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso
-          if (( ! git diff --exit-code ${BRANCHNAME} origin/master -- client/signup) && (! ${LIVEBRANCHES}==true ); then
+          if (( ! git diff --exit-code ${BRANCHNAME} origin/master -- client/signup) && (! ${LIVEBRANCHES}==true )); then
               echo "Running Signup Tests"
               echo "export SPLIT_BY=\"--split-by=filesize \"" >> $BASH_ENV
           else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,9 @@ jobs:
             - "~/.npm"
       - run: cd wp-calypso/test/e2e && npm run decryptconfig
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
-      - run: |
+      - run:
+          name: Check whether to run all signup tests
+          command: |
           cd wp-calypso
           if [[ -n $(git diff --exit-code .. origin/master -- client/signup) || -n $(git diff --exit-code .. origin/master -- client/blocks/signup-form) || -n $(git diff --exit-code .. origin/master -- client/lib/signup) ]] || ! ${LIVEBRANCHES} || ${FORCE_ALL}; then
               echo "Running All Signup Tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,14 +115,14 @@ jobs:
       - run:
           name: Check whether to run all signup tests
           command: |
-          cd wp-calypso
-          if [[ -n $(git diff --exit-code .. origin/master -- client/signup) || -n $(git diff --exit-code .. origin/master -- client/blocks/signup-form) || -n $(git diff --exit-code .. origin/master -- client/lib/signup) ]] || ! ${LIVEBRANCHES} || ${FORCE_ALL}; then
-              echo "Running All Signup Tests"
-              echo "export SPLIT_BY=\"--split-by=filesize \"" >> $BASH_ENV
-          else
-              echo "Running Subset of Signup Tests"
-              echo "export SUITE_TAG=\"parallel\"" >> $BASH_ENV
-          fi
+            cd wp-calypso
+            if [[ -n $(git diff --exit-code .. origin/master -- client/signup) || -n $(git diff --exit-code .. origin/master -- client/blocks/signup-form) || -n $(git diff --exit-code .. origin/master -- client/lib/signup) ]] || ! ${LIVEBRANCHES} || ${FORCE_ALL}; then
+                echo "Running All Signup Tests"
+                echo "export SPLIT_BY=\"--split-by=filesize \"" >> $BASH_ENV
+            else
+                echo "Running Subset of Signup Tests"
+                echo "export SUITE_TAG=\"parallel\"" >> $BASH_ENV
+            fi
       - run: |
           cd wp-calypso/test/e2e
           echo "export TESTFILES=\"$(circleci tests glob "specs*/**/*spec.js" | circleci tests split ${SPLIT_BY}| tr '\n' ',' )\"" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,7 @@ jobs:
       - run: sudo chmod +x wp-calypso/test/e2e/node_modules/.bin/magellan
       - run: |
           cd wp-calypso
-          if ! git diff --exit-code ${E2E_BRANCH} master --client/signup; then
+          if [! git diff --exit-code ${BRANCHNAME} master -- client/signup] && [! ${LIVEBRANCHES}=true ]; then
               echo "Running Signup Tests"
           else
               echo "export SUITE_TAG=\"parallel\"" >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,9 +115,10 @@ jobs:
       - run: |
           cd wp-calypso
           if [[ -n $(git diff --exit-code .. origin/master -- client/signup) || -n $(git diff --exit-code .. origin/master -- client/blocks/signup-form) || -n $(git diff --exit-code .. origin/master -- client/lib/signup) ]] || ! ${LIVEBRANCHES} || ${FORCE_ALL}; then
-              echo "Running Signup Tests"
+              echo "Running All Signup Tests"
               echo "export SPLIT_BY=\"--split-by=filesize \"" >> $BASH_ENV
           else
+              echo "Running Subset of Signup Tests"
               echo "export SUITE_TAG=\"parallel\"" >> $BASH_ENV
           fi
       - run: |


### PR DESCRIPTION
This PR sets it up so that the bulk of the signup tests are only run if there are changes in the client/signup directory. We can merge this PR if we start hitting rate limit issues.

Related to https://github.com/Automattic/wp-calypso/pull/37117

To Test: Trigger a build from gh bridge to this branch using postman and a payload from the PR above. Ensure that all signup tests only run if there are changes in `client/signup`